### PR TITLE
feat(infra): implement core kubernetes deployment and service manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,30 @@ kubectl wait --namespace ingress-nginx \
   --for=condition=ready pod \
   --selector=app.kubernetes.io/component=controller \
   --timeout=300s
+```
+
+##### Containers - Core Declarative Manifests
+
+To manage the application lifecycle and routing layers inside the cluster, declarative manifests were implemented under the `k8s/` directory:
+
+- **Deployment (`deployment.yaml`)**: Spawns a high-availability layout maintaining `2` application replicas running the `hivebox-app:latest` runtime engine. It safely injects required system environments (`BASE_URL`, `ids`) directly into the container spaces.
+- **Service (`service.yaml`)**: Exposes a stable internal cluster layer (`ClusterIP`) acting as an internal load balancer pointing to target container port `8000`.
+- **Ingress (`ingress.yaml`)**: Maps specific routing rules into the `nginx` controller class. It directs external host interface requests hitting `/temperature` and `/metrics` paths straight into the internal service layer on port `80`.
+
+##### Application Deployment Runbook
+
+```bash
+# Navigate to the manifests directory
+cd k8s/
+
+# Sideload your locally compiled application image into the KIND node context
+kind load docker-image hivebox-app:latest --name hivebox-cluster
+
+# Apply the declarative runtime, networking, and edge-proxy specs
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+kubectl apply -f ingress.yaml
+
+# Verify production gateway routing functionality directly
+curl -i http://localhost/temperature
+```

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hivebox-deployment
+  namespace: default
+  labels:
+    app: hivebox
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hivebox
+  template:
+    metadata:
+      labels:
+        app: hivebox
+    spec:
+      containers:
+      - name: hivebox-api
+        image: hivebox-app:latest
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 8000
+        env:
+        - name: BASE_URL
+          value: "https://api.opensensemap.org/boxes"
+        - name: ids
+          value: "5eba5fbad46fb8001b799786,5c21ff8f919bf8001adf2488,5ade1acf223bd80019a1011c"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hivebox-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /temperature
+        pathType: Prefix
+        backend:
+          service:
+            name: hivebox-service
+            port:
+              number: 80
+      - path: /metrics
+        pathType: Prefix
+        backend:
+          service:
+            name: hivebox-service
+            port:
+              number: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hivebox-service
+  namespace: default
+spec:
+  selector:
+    app: hivebox
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000


### PR DESCRIPTION
## Overview
This Pull Request satisfies the local container orchestration and infrastructure requirements for **Phase 4 (Section 4.3: Containers)**. It establishes a fully local, production-hardened Kubernetes ecosystem using **KIND (Kubernetes in Docker)** and exposes the HiveBox FastAPI backend using declarative core manifests and an **Ingress-Nginx** edge routing layer.

---

## Architectural Mechanics & Design Choices ("The Why")

1. **Local Port Forwarding (`kind-config.yaml`)**
   - *Choice:* Configured `extraPortMappings` to dynamically bind host ports `80` and `443` straight into the cluster's control plane container.
   - *Reason:* This allows external traffic from our local Debian development engine to hit the cluster seamlessly without relying on messy, short-lived `kubectl port-forward` tunnels, mirroring how cloud load balancers handle production internet ingress.

2. **Edge Proxy Routing Layer (`ingress-nginx`)**
   - *Choice:* Integrated the official Ingress-Nginx controller manifest explicitly patched for KIND node labels (`ingress-ready=true`).
   - *Reason:* Consolidates all web endpoints into a unified reverse proxy gateway layer rather than exposing raw node ports. It secures the internal service layout and strips out verbose server headers as a security hardening best practice.

3. **High-Availability Application Schema (`k8s/deployment.yaml`)**
   - *Choice:* Instantiated a declarative Deployment keeping `replicas: 2`.
   - *Reason:* Provides baseline fault-tolerance and horizontal scaling capabilities. If an active container pod crashes or terminates, the underlying `ReplicaSet` watchdog immediately schedules an identical pod to ensure zero downtime. It also cleanly decouples configuration from runtime logic by explicitly injecting the required environment variables (`BASE_URL` and sensor `ids`).

4. **Internal Load Balancing (`k8s/service.yaml` & `k8s/ingress.yaml`)**
   - *Choice:* Created a hidden structural `ClusterIP` Service targeting container port `8000` and mapped explicit path prefixes (`/temperature` and `/metrics`) inside the Ingress rule file.
   - *Reason:* Since pod IP addresses are ephemeral and shift on every restart, the Service acts as a permanent internal load-balanced counter window. The Ingress file acts as Nginx's clipboard, letting it translate external web requests straight to that internal service boundary.

---

## What Changed?
- 📄 Added `kind-config.yaml` to specify single-node local cluster behavior and port rules.
- 📂 Created `k8s/` directory containing the core declarative blueprints:
  - `deployment.yaml`: Manages the lifecycle, 2x replicas, and injected system variables of `hivebox-app`.
  - `service.yaml`: Connects internal cluster ports to the Uvicorn application target port.
  - `ingress.yaml`: Defines Nginx path-routing specifications for `/temperature` and `/metrics`.
- 📝 Updated `README.md` with a comprehensive architectural summary and local verification runbooks.

---

## Verification & Testing Steps

To test the end-to-end pipeline introduced in this PR locally:

1. **Bring up the cluster node environment:**
   ```bash
   kind create cluster --config kind-config.yaml --name hivebox-cluster
   ```
2. **Deploy the Nginx gateway and wait for readiness:**
   ```bash
   kubectl apply -f [https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml](https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml)
    kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=300s
    ```
3. **Compile the app container image and load it inside the KIND environment:**
   ```bash
    docker build -t hivebox-app:latest .
    kind load docker-image hivebox-app:latest --name hivebox-cluster
    ```
4. **Apply the declarative application layouts:**
    ```bash
      kubectl apply -f k8s/
      ```
 5. **Verify live edge traffic directly from your terminal:**
 ```bash
curl -i http://localhost/temperature
curl -i http://localhost/metrics
```


   
   closes #12 
   