### PR TITLE
ci(workflow): isolate direct network checks and optimize triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,14 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+    paths-ignore:
+      - 'README.md'
+      - '**/README.md'
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - 'README.md'
+      - '**/README.md'
  
 jobs:
   lint:
@@ -25,8 +31,9 @@ jobs:
           pip install -r requirements.txt
           pip install pylint
  
+      # Expanded to lint your new integration test files alongside source files
       - name: Run pylint
-        run: pylint main.py print_version.py test_main.py
+        run: pylint main.py print_version.py test_main.py test_integration.py
  
       - name: Install hadolint
         run: |
@@ -55,10 +62,32 @@ jobs:
  
       - name: Run tests
         run: pytest test_main.py -v
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+
+      # Ubuntu runners include the Docker daemon out-of-the-box, 
+      # satisfying your programmatic programmatic '@pytest.mark.docker' requirements.
+      - name: Install dependencies
+        run: pip install -r requirements.txt pytest
+
+      - name: Run complete integration test grid
+        run: pytest test_integration.py -v -m direct
+
   build:
    name: Build Docker Image
    runs-on: ubuntu-latest
-   needs: test
+   needs: integration-test
    steps:
      - name: Checkout code
        uses: actions/checkout@v6.0.2


### PR DESCRIPTION
- Implement paths-ignore to skip pipeline execution on README updates.
- Append test_integration.py to the static analysis pylint matrix.
- Introduce an integration-test job targeting direct contract validation.
- Filter integration suite execution using pytest marker flags (-m direct).



closes #13 